### PR TITLE
Fix deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           cache: npm
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Install dependencies
         run: npm ci
@@ -43,7 +43,7 @@ jobs:
           npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use the latest versions of the actions to fix deprecation warnings:\n\n- Updated actions/configure-pages from v3 to v4\n- Updated actions/upload-pages-artifact from v2 to v3\n- Updated actions/deploy-pages from v2 to v4\n\nThis fixes the deployment error: 'This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3.'